### PR TITLE
Recognise multiple accept headers

### DIFF
--- a/src/ContentNegotiator.php
+++ b/src/ContentNegotiator.php
@@ -21,7 +21,10 @@ final class ContentNegotiator
 
     public function negotiate(Request $request, array $priorities)
     {
-        $header = $request->headers->get($this->header, '*');
+        $header = implode(', ', $request->headers->get($this->header, null, false));
+        if (empty($header)) {
+            $header = '*';
+        }
 
         $match = $this->negotiator->getBest($header, $priorities);
 

--- a/test/ContentNegotiatorTest.php
+++ b/test/ContentNegotiatorTest.php
@@ -43,6 +43,24 @@ final class ContentNegotiatorTest extends TestCase
 
     /**
      * @test
+     * @dataProvider typeNegotiationProvider
+     */
+    public function it_recognises_multiple_accept_headers()
+    {
+        $contentNegotiator = new ContentNegotiator(new Negotiator(), 'Accept', 'accept_type');
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/rtf', false);
+        $request->headers->set('Accept', 'text/plain', false);
+
+        $contentNegotiator->negotiate($request, ['text/plain', 'text/rtf']);
+
+        $this->assertTrue($request->attributes->has('accept_type'));
+        $this->assertEquals(new Accept('text/plain'), $request->attributes->get('accept_type'));
+    }
+
+    /**
+     * @test
      * @dataProvider languageNegotiationProvider
      */
     public function it_negotiates_other_headers(string $accept = null, string $expected)


### PR DESCRIPTION
Related to https://github.com/elifesciences/api-sdk-php/pull/168, multiple `Accept` headers are valid.

(Creating a `Request` using `createFromGlobals()` is only going to contain the first header though, as PHP has ignored the others.)